### PR TITLE
BF: important to get the window out of fullscreen mode before closing

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -428,6 +428,8 @@ class EyeTracker(EyeTrackerDevice):
             # on a successful calibration.
 
             # genv._unregisterEventMonitors()
+            genv.window.winHandle.set_fullscreen(False)
+            genv.window.winHandle.minimize()
             genv.clearAllEventBuffers()
             genv.window.close()
             del genv.window


### PR DESCRIPTION
...otherwise can be left with a black screen covering the experiment window