### PR TITLE
BF: add the implementation of _close() so eyetracker can be closed 

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -1557,6 +1557,10 @@ class EyeTracker(EyeTrackerDevice):
             printExceptionDetailsToStdErr()
             return EyeTrackerConstants.EYETRACKER_ERROR
 
+    def _close(self):
+        self.setRecordingState(False)
+        self.setConnectionState(False)
+        EyeTrackerDevice._close(self)
 
 # ================= Command Functions ==========================================
 


### PR DESCRIPTION
properly when ioServer shuts down

This BF adds the implementation of the `_close()` method so that the eyetracker can be properly shut down when an ioServer shuts down. This same method likely needs to be implemented in all other plugin packages for different eye tracker hardware, and the PsychoPy developer team might want to consider adding it to the [EyeTrackerDevice](https://github.com/psychopy/psychopy/blob/0a5945c936b0d23ea9240ec88841c05bc34866c7/psychopy/iohub/devices/eyetracker/__init__.py#L11) class directly.