### PR TITLE
ENH: enhance reliability of receiving EDF files at the end of an experiment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,6 +18,7 @@ jobs:
     
     - name: Install package and dependencies
       run: |
+        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
         python3 -m pip install -e .[docs]
     
     - name: Build docs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
     
     - name: Install package and dependencies
       run: |
+        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
         python3 -m pip install -e .[tests]
     
     - name: Run tests
@@ -42,6 +43,7 @@ jobs:
     
     - name: Install package and dependencies
       run: |
+        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
         python3 -m pip install -e .[tests]
     
     - name: Run tests
@@ -73,6 +75,7 @@ jobs:
         
         - name: Install package and dependencies
           run: |
+            python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
             python3 -m pip install -e .[tests]
         
         - name: Run tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ devices:
     
 ## Installing
 
-Install this package with the following shell command:: 
+First install the SR Research `pylink` Python module with the following shell command:
+
+    pip install --index-url=https://pypi.sr-research.com sr-research-pylink
+
+Then install this package with the following shell command:
 
     pip install psychopy-eyetracker-sr-research
 

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -197,6 +197,18 @@ class EyeTracker(EyeTrackerDevice):
                         local_file_name = self._iohub_server.dsfile.fileName[:-5]
                         EyeTracker._full_edf_name = local_file_name
                         EyeTracker._host_edf_name = default_native_data_file_name
+                    else:
+                        # If datastore file is not enabled, attempt to use the PsychoPy experiment filename
+                        psychopy_file_name = None
+                        for dev in self._iohub_server.devices:
+                            if dev.__class__.__name__ == 'Experiment':
+                                psychopy_file_name = dev.getConfiguration()['filename']
+                        if psychopy_file_name:
+                            # make sure local_file_name is relative to _local_edf_dir
+                            EyeTracker._local_edf_dir = os.path.commonprefix([self._local_edf_dir, psychopy_file_name])
+                            local_file_name = os.path.relpath(psychopy_file_name, self._local_edf_dir)
+                            EyeTracker._full_edf_name = local_file_name
+                            EyeTracker._host_edf_name = default_native_data_file_name
                 else:
                     r = default_native_data_file_name.rfind('.')
                     if r > 0:
@@ -217,6 +229,8 @@ class EyeTracker(EyeTrackerDevice):
             if self._host_edf_name and self._local_edf_dir and self._full_edf_name:
                 EyeTracker._active_edf_file = self._full_edf_name + '.EDF'
                 self._eyelink.openDataFile(self._host_edf_name + '.EDF')
+            else:
+                print2err('WARNING: No active EDF file opened on host PC for this session.')
 
             # Create a fileTransferDialog class that will be used when a connection is closed and
             # a native EDF file needs to be transferred from Host to Experiment PC.

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -497,7 +497,7 @@ class EyeTracker(EyeTrackerDevice):
         by using the setConnectionState(True) method for recording to be possible.
 
         Args:
-            recording (bool): if True, the eye tracker will start recording data.; false = stop recording data.
+            recording (bool): if True, the eye tracker will start recording data; false = stop recording data.
 
         Return:
             bool: the current recording state of the eye tracking device
@@ -1524,7 +1524,7 @@ class EyeTracker(EyeTrackerDevice):
                 self._eyelink.sendCommand('use_ellipse_fitter = NO')
             else:
                 print2err(
-                    '** EyeLink Warning: _setPupilDetection: Unrecofnized pupil fitting type: ',
+                    '** EyeLink Warning: _setPupilDetection: Unrecognized pupil fitting type: ',
                     pmode)
                 return EyeTrackerConstants.EYETRACKER_ERROR
             return EyeTrackerConstants.EYETRACKER_OK
@@ -1553,7 +1553,7 @@ class EyeTracker(EyeTrackerDevice):
                 r = 0
             else:
                 print2err(
-                    'EYELINK Error during _setEyeTrackingMode: Unknown Trackiong Mode: ', r)
+                    'EYELINK Error during _setEyeTrackingMode: Unknown Tracking Mode: ', r)
                 return EyeTrackerConstants.EYETRACKER_ERROR
             if r == 0:
                 self._eyelink.sendCommand('force_corneal_reflection = OFF')

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -295,7 +295,8 @@ class EyeTracker(EyeTrackerDevice):
 
                     if self._active_edf_file:
                         self._eyelink.closeDataFile()
-                        # NOTE: local_file_path directory must exist or file will not be saved locally.
+                        if not os.path.isdir(self._local_edf_dir):
+                            os.mkdir(self._local_edf_dir)
                         local_file_path = os.path.join(self._local_edf_dir, self._active_edf_file)
                         self._eyelink.receiveDataFile(self._host_edf_name + '.EDF', local_file_path)
                     self._eyelink.close()

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -155,9 +155,12 @@ class EyeTracker(EyeTrackerDevice):
                 tracker_config['enable_interface_without_connection'] = True
                 self.setConnectionState(True)
 
+            # Add additional EyeLink command functions as options for the overloaded
+            # EyeTracker.sendCommand() method. Note that this is separate from the
+            # pylink.EyeLink.sendCommand() method despite the same method name.
             self._addCommandFunctions()
 
-            # Sets the physical ini settings, like default screen distance,
+            # Set the physical ini settings, like default screen distance,
             # monitor size, and display coordinate bounds.
             self._eyelinkSetScreenPhysicalData()
 
@@ -168,23 +171,20 @@ class EyeTracker(EyeTrackerDevice):
             else:
                 self._eyelink.sendCommand('aux_mouse_simulation = NO')
 
-            # set that the EyeLink connected button box, button 5
+            # Set that the EyeLink connected button box, button 5
             # (the big button on most of supported gamepads), will initiate
             # an accept fixation command.
             self._eyelink.sendCommand("button_function 5 'accept_target_fixation'")
 
-            # Sets up the file names / paths to be used for the native EyeLink
-            # EDF file.
-            EyeTracker._local_edf_dir = EXP_SCRIPT_DIRECTORY
-
-            # Sets the 'runtime' configuration section of the eyetracker
+            # Set the 'runtime' configuration section of the eyetracker
             # settings, including eye to track, sample filtering level, etc.
             self._setRuntimeSettings(self._runtime_settings)
 
-            # calibration related settings
-            eyelink = self._eyelink
+            # Calibration related settings
+            self.sendCalibrationSettingsCommands(self._eyelink, tracker_config.get('calibration'))
 
-            self.sendCalibrationSettingsCommands(eyelink, tracker_config.get('calibration'))
+            # Set up the file names / paths to be used for the native EyeLink EDF file.
+            EyeTracker._local_edf_dir = EXP_SCRIPT_DIRECTORY
 
             # native data recording file
             default_native_data_file_name = tracker_config.get('default_native_data_file_name', None)
@@ -218,9 +218,8 @@ class EyeTracker(EyeTrackerDevice):
                 EyeTracker._active_edf_file = self._full_edf_name + '.EDF'
                 self._eyelink.openDataFile(self._host_edf_name + '.EDF')
 
-            # Creates a fileTransferDialog class that will be used when a connection is closed and
-            # a native EDF file needs to be transferred from Host to Experiment
-            # PC.
+            # Create a fileTransferDialog class that will be used when a connection is closed and
+            # a native EDF file needs to be transferred from Host to Experiment PC.
             EyeTracker._eyelink.progressUpdate = self._fileTransferProgressUpdate
         except Exception:
             print2err(' ---- Error during EyeLink EyeTracker Initialization ---- ')
@@ -282,7 +281,7 @@ class EyeTracker(EyeTrackerDevice):
 
                     if self._active_edf_file:
                         self._eyelink.closeDataFile()
-                        # Note: local_file_path directory must exist or file will not be saved locally.
+                        # NOTE: local_file_path directory must exist or file will not be saved locally.
                         local_file_path = os.path.join(self._local_edf_dir, self._active_edf_file)
                         self._eyelink.receiveDataFile(self._host_edf_name + '.EDF', local_file_path)
                     self._eyelink.close()
@@ -1173,6 +1172,7 @@ class EyeTracker(EyeTrackerDevice):
             printExceptionDetailsToStdErr()
 
     def _setRuntimeSettings(self, runtimeSettings):
+        """applies user defined runtime settings to the eye tracker."""
         for pkey, v in runtimeSettings.items():
             if pkey == 'sample_filtering':
                 all_filters = {'FILTER_FILE': 'FILTER_LEVEL_2',
@@ -1492,8 +1492,7 @@ class EyeTracker(EyeTrackerDevice):
             self._COMMAND_TO_FUNCTION['applyDriftCorrect'] = _applyDriftCorrect
             self._COMMAND_TO_FUNCTION['setIPAddress'] = _setIPAddress
             self._COMMAND_TO_FUNCTION['setLockEye'] = _setLockEye
-            self._COMMAND_TO_FUNCTION[
-                'setLocalResultsDir'] = _setNativeRecordingFileSaveDir
+            self._COMMAND_TO_FUNCTION['setLocalResultsDir'] = _setNativeRecordingFileSaveDir
         except Exception:
             print2err('EYELINK Error during _addCommandFunctions:')
             printExceptionDetailsToStdErr()

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -449,7 +449,7 @@ class EyeTracker(EyeTrackerDevice):
             # {'message': 'calibration_result: 0', 'result': 1000}
             # on a successful calibration.
 
-            # genv._unregisterEventMonitors()
+            genv._unregisterEventMonitors()
             genv.window.winHandle.set_fullscreen(False)
             genv.window.winHandle.minimize()
             genv.clearAllEventBuffers()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ urls.changelog = "https://github.com/psychopy/psychopy-eyetracker-sr-research/bl
 urls.documentation = "https://pages.github.com/psychopy/psychopy-eyetracker-sr-research"
 urls.repository = "https://github.com/psychopy/psychopy-eyetracker-sr-research"
 dependencies = [
-  "pylink",
+  "sr-research-pylink",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR contains 

- a BF to unregister ioHub keyboard monitor of escape and space releases as discussed [here](https://github.com/psychopy/psychopy/pull/6466).
- ENH commits to make receiving EDF files at the end of an experiment more reliable. Specifically, dependent on the merge of this [PR](https://github.com/psychopy/psychopy/pull/6555) into the main psychopy release, the current PR will use the exposed PsychoPy filename when `dsfile` is `None` to open and download EDF files with the same naming convention as the rest of subject data files. If the saving folder does not exist, we also `mkdir` to make sure we do save the eye tracking data.
- BF around dependency of SR research package `sr-research-pylink` from their own PyPI server.