### PR TITLE
Fix using this package as a plugin through entry-points to PsychoPy

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/default_eyetracker.yaml
@@ -5,7 +5,7 @@
 # created by the ioHub Process will be assigned the default value
 # indicated here.
 #
-eyetracker.sr_research.eyelink.EyeTracker:
+eyetracker.hw.sr_research.eyelink.EyeTracker:
     # name: The unique name to assign to the device instance created.
     #   The device is accessed from within the PsychoPy script 
     #   using the name's value; therefore it must be a valid Python

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/default_eyetracker.yaml
@@ -5,7 +5,7 @@
 # created by the ioHub Process will be assigned the default value
 # indicated here.
 #
-eyetracker.hw.sr_research.eyelink.EyeTracker:
+eyetracker.eyelink.EyeTracker:
     # name: The unique name to assign to the device instance created.
     #   The device is accessed from within the PsychoPy script 
     #   using the name's value; therefore it must be a valid Python

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -202,7 +202,7 @@ class EyeTracker(EyeTrackerDevice):
                         psychopy_file_name = None
                         for dev in self._iohub_server.devices:
                             if dev.__class__.__name__ == 'Experiment':
-                                psychopy_file_name = dev.getConfiguration()['filename']
+                                psychopy_file_name = dev.getConfiguration().get('filename')
                         if psychopy_file_name:
                             # make sure local_file_name is relative to _local_edf_dir
                             EyeTracker._local_edf_dir = os.path.commonprefix([self._local_edf_dir, psychopy_file_name])

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/supported_config_settings.yaml
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/supported_config_settings.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.sr_research.eyelink.EyeTracker:
+eyetracker.eyelink.EyeTracker:
     name: tracker
     enable: IOHUB_BOOL
     save_events: IOHUB_BOOL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ tests = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["", "psychopy_eyetracker_sr_research",]
+where = [""]
+include = ["psychopy_eyetracker_sr_research*"]
 
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
 eyelink = "psychopy_eyetracker_sr_research.sr_research.eyelink"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ tests = [
 where = ["", "psychopy_eyetracker_sr_research",]
 
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-eyelink = "psychopy_eyetracker_eyelogic.sr_research.eyelink"
+eyelink = "psychopy_eyetracker_sr_research.sr_research.eyelink"
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]


### PR DESCRIPTION
After these changes in this PR and the commits in https://github.com/psychopy/psychopy/pull/6610, I'm able to create proper `ioHubDeviceView` for EyeLink eyetrackers and call the calibration routine when running an experiment from Builder. Note that the changes made the yaml config variable names and the entry point correction here might need to be mirrored to the other eyetracker plugin repos in order for these fixes to work globally (for gazepoint, eyelogic, etc...)

----------------------------

**However an average user will not be able to use this plugin at the moment.** The main problem is that `pyproject.toml` specifies a dependency for `sr-research-pylink`, which cannot be automatically installed over PyPI through pip. Have you decided to resolve this issue?

One additional complication is that even if you distribute `sr-research-pylink` as part of the standalone PsychoPy app, the install will still fail at the moment because the GUI installation process in PsychoPy still doesn't check existing packages installed in site-packages as I first pointed out here: https://github.com/psychopy/psychopy-crs/pull/1. I just checked on `dev` and it still doesn't use existing dependencies. So right now one would have to manually put `sr-research-pylink` into `~/.psychopy3/packages/lib/python/site-packages` in order for the install button of `psychopy-eyetracker-sr-research` to work inside the Plugins & Packages manager of PsychoPy. 

Since `psychopy-eyetracker-sr-research` is not released yet, I simply did `pip install .` of this repo and created softlinks in `~/.psychopy3/packages/lib/python/site-packages` to the `.dist-info` and `psychopy-eyetracker-sr-research` package in order to test things out. You could do the same for the other devices if you are checking how the Builder works with the new entry-point logics on the PsychoPy side.

By the way, the current PyPI release at https://pypi.org/project/psychopy-eyetracker-sr-research/ is very problematic because it will automatically install the incorrect `https://pypi.org/project/PyLink/` package, which overrides the correct `pylink` shipped with PsychoPy. So installing this plugin right now will prevent the users from using the standalone PsychoPy to work with EyeLink all together.

Finally, it is usually discouraged to use the setuptools `:find` directives as
```
[tool.setuptools.packages.find]
where = ["", "psychopy_eyetracker_sr_research",]
```
This will install all the folders `docs_src`, `tests`, etc. under the root level as separate packages. Because the other eyetracker plugins all have the same top-level folder names and even the same filenames inside these ancillary folders, this conflict will prevent `pip install` from completing the installation all together. I believe users just need the `psychopy_eyetracker_sr_research` package hence the change. When running pytests during CI you can do `pip install -e .` if you really need to import the docs and tests folders as packages. But then again, assuming the working directory is the top level of the repo, you can do `from docs_src import *` already anyways.