### PR TITLE
SYS: update version to 0.0.4 and prepare for updating the build on PyPI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Build docs
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
     - name: Checkout
@@ -15,24 +15,28 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    
+
+    - name: Prepare to build pytables for macos
+      if: runner.os == 'macOS' 
+      run: |
+        brew install hdf5
+        export HDF5_DIR=$(brew --prefix hdf5)
+        python3 -m pip install numpy numexpr cython
+
     - name: Install package and dependencies
-      run: |
-        python3 -m pip install -e .[docs]
-    
+      run: python3 -m pip install -e .[docs]
+
     - name: Build docs
-      run: |
-        sphinx-build docs_src docs -b dirhtml
-    
+      run: sphinx-build docs_src docs -b dirhtml
+
     - name: Bypass Jekyll
-      run: |
-        echo "" > docs/.nojekyll
+      run: echo "" > docs/.nojekyll
 
     - name: Commit
       run: |
         git add --all
         git commit --all -m "sys: Build documentation"
-    
+
     - name: Push
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,13 +12,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     
     - name: Install package and dependencies
       run: |
-        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
         python3 -m pip install -e .[docs]
     
     - name: Build docs

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,15 +20,15 @@ jobs:
           uses: actions/setup-python@v5
           with:
             python-version: '3.10'
-        
+
         - name: Install packages
           run: |
             python -m pip install build twine
-        
+
         - name: Build
           run: |
             python -m build
-        
+
         - name: Attach binaries
           if: startsWith(github.ref, 'refs/tags/')
           uses: softprops/action-gh-release@v2
@@ -36,7 +36,7 @@ jobs:
             token: ${{ secrets.GITHUB_TOKEN }}
             files: |
               dist/*
-        
+
         - name: Upload to PyPi
           if: startsWith(github.ref, 'refs/tags/')
           uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -17,7 +17,7 @@ jobs:
         - uses: actions/checkout@master
 
         - name: Setup Python
-          uses: actions/setup-python@v3
+          uses: actions/setup-python@v5
           with:
             python-version: '3.10'
         

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        Os: ["macos-latest", "windows-latest", "ubuntu-latest"]
+        os: ["macos-latest", "windows-latest", "ubuntu-latest"]
 
     steps:
     - name: Checkout
@@ -21,8 +21,15 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    
-    - name: Prepare to build wx for Ubuntu
+
+    - name: Prepare to build pytables for macos
+      if: runner.os == 'macOS' 
+      run: |
+        brew install hdf5
+        export HDF5_DIR=$(brew --prefix hdf5)
+        python3 -m pip install numpy numexpr cython
+
+    - name: Prepare to build wx for ubuntu
       if: runner.os == 'Linux' 
       run: |
         python3 -m pip install wheel six distro attrdict3
@@ -35,6 +42,6 @@ jobs:
 
     - name: Install package and dependencies
       run: python3 -m pip install -e .[tests]
-    
+
     - name: Run tests
       run: pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,78 +6,35 @@ on:
     branches: [ main ]
 
 jobs:
-  mac-tests:
-    name: Run tests on Mac
-    runs-on: macos-11
+  run-tests:
+    name: Run tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        Os: ["macOS-11", "windows-latest", "ubuntu-latest"]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     
-    - name: Install package and dependencies
+    - name: Prepare to build wx for Ubuntu
+      if: runner.os == 'Linux' 
       run: |
-        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
-        python3 -m pip install -e .[tests]
+        python3 -m pip install wheel six distro attrdict3
+        sudo apt-get update
+        sudo apt-get install -y -qq python3-dev libgtk-3-dev
+        sudo apt-get install -y -qq libgstreamer1.0-0 gstreamer1.0-plugins-base
+        sudo apt-get install -y -qq libwebkit2gtk-4.0-dev
+        sudo apt-get install -y -qq libpng-dev libjpeg-dev libtiff-dev libnotify-dev libsm-dev
+        sudo apt-get install -y -qq libsdl2-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.
+
+    - name: Install package and dependencies
+      run: python3 -m pip install -e .[tests]
     
     - name: Run tests
-      run: |
-        pytest
-  
-  windows-tests:
-    name: Run tests on Windows
-    runs-on: windows-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    
-    - name: Install package and dependencies
-      run: |
-        python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
-        python3 -m pip install -e .[tests]
-    
-    - name: Run tests
-      run: |
-        pytest
-    
-  linux-tests:
-    name: Run tests on Linux
-    runs-on: ubuntu-latest
-
-    steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-    
-        - name: Set up Python
-          uses: actions/setup-python@v4
-          with:
-            python-version: "3.10"
-        
-        - name: Prepare to build wx
-          run: |
-            python3 -m pip install wheel six distro attrdict3
-            sudo apt-get update
-            sudo apt-get install -y -qq python3-dev libgtk-3-dev
-            sudo apt-get install -y -qq libgstreamer1.0-0 gstreamer1.0-plugins-base
-            sudo apt-get install -y -qq libwebkit2gtk-4.0-dev
-            sudo apt-get install -y -qq libpng-dev libjpeg-dev libtiff-dev libnotify-dev libsm-dev
-            sudo apt-get install -y -qq libsdl2-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.
-        
-        - name: Install package and dependencies
-          run: |
-            python3 -m pip install --index-url=https://pypi.sr-research.com sr-research-pylink
-            python3 -m pip install -e .[tests]
-        
-        - name: Run tests
-          run: |
-            pytest
+      run: pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        Os: ["macOS-11", "windows-latest", "ubuntu-latest"]
+        Os: ["macos-latest", "windows-latest", "ubuntu-latest"]
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -5,26 +5,23 @@ eyetrackers (via ioHub)
 
 ## Supported Devices
 
-Installing this package alongside PsychoPy will enable support for the following 
-devices:
+Installing this package alongside PsychoPy will enable support for the following devices:
 
 * Supported SR Research EyeLink devices
-    
+
 ## Installing
 
-First install the SR Research `pylink` Python module with the following shell command:
-
-    pip install --index-url=https://pypi.sr-research.com sr-research-pylink
-
-Then install this package with the following shell command:
+Install this package with the following shell command:
 
     pip install psychopy-eyetracker-sr-research
 
-You may also use PsychoPy's builtin plugin/package manager to install this 
-package.
+You may also use PsychoPy's built-in plugin/package manager to install this package.
+
+## Alternative
+There is a different plug-in package [`psychopy-eyelink`](https://pypi.org/project/psychopy-eyelink/) provided by SR Research that adds more EyeLink-specific Eyetracking components to the PsychoPy Builder view to interact with SR Research EyeLink devices directly (without using ioHub). Note that when [`psychopy-eyelink`] is used, its component implementations are independent of the [`EyeTracking` tab in the `Experiment Setting` window](https://psychopy.org/hardware/eyeTracking.html).
+
+You may use either `psychopy-eyetracker-sr-research` or `psychopy-eyelink` (but not both) to communicate with a SR Research EyeLink eyetracker.
 
 ## Usage
 
-Once the package is installed, PsychoPy will automatically load it when started 
-and the `psychopy.iohub.devices.eyetracker.hw.sr_research` namespace will 
-contain the loaded objects.
+Once the package is installed, PsychoPy will automatically load it when started and the `psychopy.iohub.devices.eyetracker.hw.sr_research` namespace will contain the loaded objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psychopy-eyetracker-sr-research"
-version = "0.0.3"
+version = "0.0.4"
 description = "Extension package for PsychoPy which adds support for SR Research eyetrackers (via ioHub)."
 readme = "README.md"
 requires-python = ">= 3.7"


### PR DESCRIPTION
@TEParsons, great news! SR research is now distributing [`sr-research-pylink` on PyPI ](https://pypi.org/project/sr-research-pylink/). I just tested a pure `pip install` of this package and it works.

I've updated the README to remove the now unnecessary separate `pip install --index-url` call and provided an `Alternative` section to point people to the alternative option of using the `psychopy-eyelink` plugin to communicate with EyeLink devices. I've bumped the version number to 0.0.4 as well.

**When you get a chance, could you merge this PR, build the latest version, and update the [PyPI distribution of this package](https://pypi.org/project/psychopy-eyetracker-sr-research/)? I'll then confirm that I can use the PsychoPy Plugin/Package manager to install it as well.** 

_P.S. I've also installed and tested the new `psychopy-eyelink` from SR Research, which works fine. All its dependencies are on PyPI already and can be `pip install`ed easily. Even though the EyeLink `StartRecording` and `StopRecording` differ slightly from the PsychoPy `EyetrackerRecordComponent` we worked on, I think it is a good alternative to the current plugin to interact with eyetrackers (albeit being specific to EyeLink and not open-source, of course). Therefore, you guys may want to add `psychopy-eyelink` to the list of possible plugins in the Plugin/Package manager. Right now Psychopy 2024.2.0 doesn't include it._