### PR TITLE
BF: close existing EyeLinkCustomDisplay during runSetupProcedure

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -470,6 +470,7 @@ class EyeTracker(EyeTrackerDevice):
             genv.window.close()
             del genv.window
             del genv
+            pylink.closeGraphics()
 
             self.setRecordingState(already_recording)
 

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -7,6 +7,7 @@ import gevent
 import threading
 import pylink
 import numpy as np
+import pylink.eyelink
 
 try:
     from psychopy.gui.wxgui import ProgressBarDialog
@@ -438,6 +439,10 @@ class EyeTracker(EyeTrackerDevice):
 
             genv = EyeLinkCoreGraphicsIOHubPsychopy(self, calibration_args)
 
+            # close existing graphics if this method has been called before
+            if pylink.eyelink.customGraphics:
+                pylink.closeGraphics()
+
             pylink.openGraphicsEx(genv)
 
             self._eyelink.doTrackerSetup()
@@ -470,7 +475,6 @@ class EyeTracker(EyeTrackerDevice):
             genv.window.close()
             del genv.window
             del genv
-            pylink.closeGraphics()
 
             self.setRecordingState(already_recording)
 

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -7,7 +7,6 @@ import gevent
 import threading
 import pylink
 import numpy as np
-import pylink.eyelink
 
 try:
     from psychopy.gui.wxgui import ProgressBarDialog


### PR DESCRIPTION
We need to close any existing `EyeLinkCoreGraphicsIOHubPsychopy` during `runSetupProcedure` so that multiple calibration routines can be called within the same experiment. However, `EyeLinkCoreGraphicsIOHubPsychopy` must be defined for the end of an experiment in order for `receiveDataFile()` that makes a `get_input_keys()` call to work.