### PR TITLE
NF: Add imageBackdrop to EyeTracker interface

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -609,10 +609,7 @@ class EyeTracker(EyeTrackerDevice):
         """imageBackdrop transfers an image to the host PC as backdrop for gaze cursors.
 
         Args:
-            iwidth (int): Original image width.
-            iheight (int): Original image height.
-            pixels (list[list[tuple[int, int, int]]]): Pixels of the image in the following format:
-                pixels = [line_1, line_2, ...]; line = [pix1, pix2, ...]; pix = (r, g, b)
+            filename (str): Path to the image file (any file type supported by PIL.Image).
             xs (int): Crop x position (source).
             ys (int): Crop y position (source).
             width (int): Crop width (source).

--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -605,6 +605,34 @@ class EyeTracker(EyeTrackerDevice):
         except Exception:
             printExceptionDetailsToStdErr()
 
+    def imageBackdrop(self, filename, xs, ys, width, height, xd, yd, xferoptions):
+        """imageBackdrop transfers an image to the host PC as backdrop for gaze cursors.
+
+        Args:
+            iwidth (int): Original image width.
+            iheight (int): Original image height.
+            pixels (list[list[tuple[int, int, int]]]): Pixels of the image in the following format:
+                pixels = [line_1, line_2, ...]; line = [pix1, pix2, ...]; pix = (r, g, b)
+            xs (int): Crop x position (source).
+            ys (int): Crop y position (source).
+            width (int): Crop width (source).
+            height (int): Crop height (source).
+            xd (int): X position (destination).
+            yd (int): Y position (destination).
+            xferoptions (int): Transfer options determining how bitmap is processed.
+                Any bitwise OR combination of the following constants:
+                - pylink.BX_AVERAGE: Averaging combined pixels
+                - pylink.BX_DARKEN: Choosing darkest and keep thin dark lines.
+                - pylink.BX_LIGHTEN: Choosing darkest and keep thin white lines.
+                - pylink.BX_MAXCONTRAST: Maximizes contrast.
+                - pylink.BX_NODITHER: Disables the dithering of the image.
+                - pylink.BX_GRAYSCALE: Converts the image to grayscale.
+        """
+        try:
+            self._eyelink.imageBackdrop(filename, xs, ys, width, height, xd, yd, xferoptions)
+        except Exception:
+            printExceptionDetailsToStdErr()
+
     def _poll(self):
         try:
             if self._eyelink is None:


### PR DESCRIPTION
This makes it possible to use `eyetracker.imageBackdrop(...)` to set a backdrop image on the host PC through the ioHub interface.

Pylink also has `bitmapBackdrop()`, which directly sends a bitmap array instead of a filename, but when using this with ioHub, this bitmap would have to be sent to the ioHub server first, which turns out to be quite slow for larger images. With `imageBackdrop()`, the image is loaded in the server process.

Tested on an EyeLink 1000 Plus.