### PR TITLE
FF: Remove maximum length constraint for EDF file name

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/supported_config_settings.yaml
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/supported_config_settings.yaml
@@ -90,7 +90,6 @@ eyetracker.eyelink.EyeTracker:
     default_native_data_file_name: 
         IOHUB_STRING:
             min_length: 0
-            max_length: 7
     runtime_settings:
         sampling_rate:
             IOHUB_LIST:


### PR DESCRIPTION
Currently specifying an EDF filename with a length >7 using `default_native_data_file_name`  is not possible (rejected during config validation). This constraint is not necessary, since filenames that are longer than 7 characters are automatically shortened on the host PC here: https://github.com/psychopy/psychopy-eyetracker-sr-research/blob/e71ecb12774239786c1a62be9f23b0749b978413/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py#L218-L222

This PR removes the `max_length` constraint for `default_native_data_file_name`.