### PR TITLE
Fix coordinate space in screen_pixel_coords and DISPLAY_COORDS

### DIFF
--- a/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
+++ b/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py
@@ -1431,8 +1431,8 @@ class EyeTracker(EyeTrackerDevice):
 
             # calibration coord space
             l, t, r, b = self._display_device.getBounds()
-            w = r - l
-            h = b - t
+            w = r - l - 1
+            h = b - t - 1
             eyelink.sendCommand(
                 'screen_pixel_coords %.2f %.2f %.2f %.2f' %
                 (0, 0, w, h))


### PR DESCRIPTION
According to SR research, the coordinate space for the `screen_pixel_coords` command and the `DISPLAY_COORDS` message should be the resolution - 1 to reflect the index of the last pixel (see https://www.sr-research.com/support/thread-9129.html).